### PR TITLE
Extend (and fix) automation of install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This brings together several resources that create an easy-to-use dictionary exp
 
 ## Setup
 
+#### Automated
+
+`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/canadaduane/pop-dictionary/main/install.sh)"`
+
+#### Manual
+
 1. Install GoldenDict (e.g. via flatpak)
 2. Install Dictionaries
 3. Install Pop Launcher "define" plugin
@@ -17,4 +23,4 @@ See the `install.sh` script which automates steps 2 & 3.
 
 ## English Dictionaries
 
-See `dictionaries.md` for a list of sources of English language dictionaries, freely available.
+See `dictionaries.md` for a list of sources of English language dictionaries, freely available. Then you can download that dictionary to `~/.pop-dictionary/dictionaries` and extract.

--- a/goldendict-config
+++ b/goldendict-config
@@ -1,0 +1,179 @@
+<config>
+ <paths>
+  <path recursive="1">/run/user/1000/doc/87f6f0ac/.dictionaries</path>
+ </paths>
+ <sounddirs/>
+ <dictionaryOrder id="0" name="">
+  <mutedDictionaries/>
+ </dictionaryOrder>
+ <inactiveDictionaries id="0" name="">
+  <mutedDictionaries/>
+ </inactiveDictionaries>
+ <groups nextId="1"/>
+ <hunspell dictionariesPath=""/>
+ <transliteration>
+  <enableRussianTransliteration>0</enableRussianTransliteration>
+  <enableGermanTransliteration>0</enableGermanTransliteration>
+  <enableGreekTransliteration>0</enableGreekTransliteration>
+  <enableBelarusianTransliteration>0</enableBelarusianTransliteration>
+  <romaji>
+   <enable>0</enable>
+   <enableHepburn>1</enableHepburn>
+   <enableNihonShiki>0</enableNihonShiki>
+   <enableKunreiShiki>0</enableKunreiShiki>
+   <enableHiragana>1</enableHiragana>
+   <enableKatakana>1</enableKatakana>
+  </romaji>
+ </transliteration>
+ <forvo>
+  <enable>0</enable>
+  <apiKey></apiKey>
+  <languageCodes></languageCodes>
+ </forvo>
+ <mediawikis>
+  <mediawiki id="ae6f89aac7151829681b85f035d54e48" url="https://en.wikipedia.org/w" name="English Wikipedia" icon="" enabled="1"/>
+  <mediawiki id="affcf9678e7bfe701c9b071f97eccba3" url="https://en.wiktionary.org/w" name="English Wiktionary" icon="" enabled="0"/>
+  <mediawiki id="8e0c1c2b6821dab8bdba8eb869ca7176" url="https://ru.wikipedia.org/w" name="Russian Wikipedia" icon="" enabled="0"/>
+  <mediawiki id="b09947600ae3902654f8ad4567ae8567" url="https://ru.wiktionary.org/w" name="Russian Wiktionary" icon="" enabled="0"/>
+  <mediawiki id="a8a66331a1242ca2aeb0b4aed361c41d" url="https://de.wikipedia.org/w" name="German Wikipedia" icon="" enabled="0"/>
+  <mediawiki id="21c64bca5ec10ba17ff19f3066bc962a" url="https://de.wiktionary.org/w" name="German Wiktionary" icon="" enabled="0"/>
+  <mediawiki id="96957cb2ad73a20c7a1d561fc83c253a" url="https://pt.wikipedia.org/w" name="Portuguese Wikipedia" icon="" enabled="0"/>
+  <mediawiki id="ed4c3929196afdd93cc08b9a903aad6a" url="https://pt.wiktionary.org/w" name="Portuguese Wiktionary" icon="" enabled="0"/>
+  <mediawiki id="f3b4ec8531e52ddf5b10d21e4577a7a2" url="https://el.wikipedia.org/w" name="Greek Wikipedia" icon="" enabled="0"/>
+  <mediawiki id="5d45232075d06e002dea72fe3e137da1" url="https://el.wiktionary.org/w" name="Greek Wiktionary" icon="" enabled="0"/>
+ </mediawikis>
+ <websites>
+  <website id="b88cb2898e634c6638df618528284c2d" inside_iframe="1" url="https://www.google.com/search?q=define:%GDWORD%&amp;hl=en" name="Google En-En (Oxford)" icon="" enabled="0"/>
+  <website id="f376365a0de651fd7505e7e5e683aa45" inside_iframe="1" url="https://www.urbandictionary.com/define.php?term=%GDWORD%" name="Urban Dictionary" icon="" enabled="0"/>
+  <website id="324ca0306187df7511b26d3847f4b07c" inside_iframe="1" url="https://multitran.ru/c/m.exe?CL=1&amp;l1=1&amp;s=%GD1251%" name="Multitran (En)" icon="" enabled="0"/>
+  <website id="924db471b105299c82892067c0f10787" inside_iframe="1" url="http://lingvopro.abbyyonline.com/en/Search/en-ru/%GDWORD%" name="Lingvo (En-Ru)" icon="" enabled="0"/>
+  <website id="087a6d65615fb047f4c80eef0a9465db" inside_iframe="1" url="http://michaelis.uol.com.br/moderno/ingles/index.php?lingua=portugues-ingles&amp;palavra=%GDISO1%" name="Michaelis (Pt-En)" icon="" enabled="0"/>
+ </websites>
+ <dictservers/>
+ <programs>
+  <program id="428b4c2b905ef568a43d9a16f59559b0" commandLine="festival --tts" name="Festival" type="0" icon="" enabled="0"/>
+  <program id="2cf8b3a60f27e1ac812de0b57c148340" commandLine="espeak %GDWORD%" name="Espeak" type="0" icon="" enabled="0"/>
+  <program id="4f898f7582596cea518c6b0bfdceb8b3" commandLine="man -a --html=/bin/cat %GDWORD%" name="Manpages" type="2" icon="" enabled="0"/>
+  <program id="4cfed3f5b18b036b78c0390e73c7c787" commandLine="trans -e google -s en -t zh -show-original y -show-original-phonetics n -show-translation y -no-ansi -show-translation-phonetics n -show-prompt-message n -show-languages y -show-original-dictionary n -show-dictionary n -show-alternatives n &amp;quot;%GDWORD%&amp;quot;" name="Google Translate" type="1" icon="" enabled="0"/>
+ </programs>
+ <voiceEngines/>
+ <mutedDictionaries/>
+ <popupMutedDictionaries/>
+ <preferences>
+  <interfaceLanguage></interfaceLanguage>
+  <helpLanguage></helpLanguage>
+  <displayStyle></displayStyle>
+  <newTabsOpenAfterCurrentOne>0</newTabsOpenAfterCurrentOne>
+  <newTabsOpenInBackground>1</newTabsOpenInBackground>
+  <hideSingleTab>0</hideSingleTab>
+  <mruTabOrder>0</mruTabOrder>
+  <hideMenubar>0</hideMenubar>
+  <enableTrayIcon>1</enableTrayIcon>
+  <startToTray>0</startToTray>
+  <closeToTray>1</closeToTray>
+  <autoStart>0</autoStart>
+  <doubleClickTranslates>1</doubleClickTranslates>
+  <selectWordBySingleClick>0</selectWordBySingleClick>
+  <escKeyHidesMainWindow>0</escKeyHidesMainWindow>
+  <zoomFactor>1</zoomFactor>
+  <helpZoomFactor>1</helpZoomFactor>
+  <wordsZoomLevel>0</wordsZoomLevel>
+  <enableMainWindowHotkey>1</enableMainWindowHotkey>
+  <mainWindowHotkey>Ctrl+F11, Ctrl+F11</mainWindowHotkey>
+  <enableClipboardHotkey>1</enableClipboardHotkey>
+  <clipboardHotkey>Ctrl+C, Ctrl+C</clipboardHotkey>
+  <enableScanPopup>1</enableScanPopup>
+  <startWithScanPopupOn>0</startWithScanPopupOn>
+  <enableScanPopupModifiers>0</enableScanPopupModifiers>
+  <scanPopupModifiers>0</scanPopupModifiers>
+  <scanPopupAltMode>0</scanPopupAltMode>
+  <scanPopupAltModeSecs>3</scanPopupAltModeSecs>
+  <ignoreOwnClipboardChanges>0</ignoreOwnClipboardChanges>
+  <scanToMainWindow>0</scanToMainWindow>
+  <ignoreDiacritics>0</ignoreDiacritics>
+  <showScanFlag>0</showScanFlag>
+  <scanPopupUseUIAutomation>1</scanPopupUseUIAutomation>
+  <scanPopupUseIAccessibleEx>1</scanPopupUseIAccessibleEx>
+  <scanPopupUseGDMessage>1</scanPopupUseGDMessage>
+  <scanPopupUnpinnedWindowFlags>0</scanPopupUnpinnedWindowFlags>
+  <scanPopupUnpinnedBypassWMHint>0</scanPopupUnpinnedBypassWMHint>
+  <pronounceOnLoadMain>0</pronounceOnLoadMain>
+  <pronounceOnLoadPopup>0</pronounceOnLoadPopup>
+  <useInternalPlayer>1</useInternalPlayer>
+  <internalPlayerBackend>FFmpeg+libao</internalPlayerBackend>
+  <audioPlaybackProgram>mplayer</audioPlaybackProgram>
+  <alwaysOnTop>0</alwaysOnTop>
+  <searchInDock>0</searchInDock>
+  <historyStoreInterval>0</historyStoreInterval>
+  <favoritesStoreInterval>0</favoritesStoreInterval>
+  <confirmFavoritesDeletion>1</confirmFavoritesDeletion>
+  <proxyserver useSystemProxy="0" enabled="0">
+   <type>0</type>
+   <host></host>
+   <port>3128</port>
+   <user></user>
+   <password></password>
+   <systemProxyUser></systemProxyUser>
+   <systemProxyPassword></systemProxyPassword>
+  </proxyserver>
+  <checkForNewReleases>1</checkForNewReleases>
+  <disallowContentFromOtherSites>0</disallowContentFromOtherSites>
+  <enableWebPlugins>0</enableWebPlugins>
+  <hideGoldenDictHeader>0</hideGoldenDictHeader>
+  <maxNetworkCacheSize>50</maxNetworkCacheSize>
+  <clearNetworkCacheOnExit>1</clearNetworkCacheOnExit>
+  <maxStringsInHistory>500</maxStringsInHistory>
+  <storeHistory>1</storeHistory>
+  <alwaysExpandOptionalParts>0</alwaysExpandOptionalParts>
+  <addonStyle></addonStyle>
+  <collapseBigArticles>0</collapseBigArticles>
+  <articleSizeLimit>2000</articleSizeLimit>
+  <limitInputPhraseLength>0</limitInputPhraseLength>
+  <inputPhraseLengthLimit>1000</inputPhraseLengthLimit>
+  <maxDictionaryRefsInContextMenu>20</maxDictionaryRefsInContextMenu>
+  <trackClipboardChanges>0</trackClipboardChanges>
+  <synonymSearchEnabled>1</synonymSearchEnabled>
+  <fullTextSearch>
+   <searchMode>0</searchMode>
+   <matchCase>0</matchCase>
+   <maxArticlesPerDictionary>100</maxArticlesPerDictionary>
+   <maxDistanceBetweenWords>2</maxDistanceBetweenWords>
+   <useMaxArticlesPerDictionary>0</useMaxArticlesPerDictionary>
+   <useMaxDistanceBetweenWords>1</useMaxDistanceBetweenWords>
+   <dialogGeometry></dialogGeometry>
+   <disabledTypes></disabledTypes>
+   <enabled>1</enabled>
+   <ignoreWordsOrder>0</ignoreWordsOrder>
+   <ignoreDiacritics>0</ignoreDiacritics>
+   <maxDictionarySize>0</maxDictionarySize>
+  </fullTextSearch>
+ </preferences>
+ <lastMainGroupId>0</lastMainGroupId>
+ <lastPopupGroupId>0</lastPopupGroupId>
+ <popupWindowState>AAAA/wAAAAH9AAAAAAAAAggAAAGTAAAABAAAAAQAAAAIAAAACPwAAAABAAAAAQAAAAEAAAAaAGQAaQBjAHQAaQBvAG4AYQByAHkAQgBhAHIDAAAAAP////8AAAAAAAAAAA==</popupWindowState>
+ <popupWindowGeometry>AdnQywADAAAAAAKkAAABLwAABNAAAALBAAACpAAAAS8AAATQAAACwQAAAAAAAAAAB4AAAAKkAAABLwAABNAAAALB</popupWindowGeometry>
+ <pinPopupWindow>0</pinPopupWindow>
+ <popupWindowAlwaysOnTop>1</popupWindowAlwaysOnTop>
+ <mainWindowState></mainWindowState>
+ <mainWindowGeometry></mainWindowGeometry>
+ <helpWindowGeometry></helpWindowGeometry>
+ <helpSplitterState></helpSplitterState>
+ <dictInfoGeometry></dictInfoGeometry>
+ <inspectorGeometry></inspectorGeometry>
+ <dictionariesDialogGeometry>AdnQywADAAAAAAADAAAAcQAAA6AAAAKpAAAAAwAAAJYAAAOgAAACqQAAAAAAAAAAB4AAAAADAAAAlgAAA6AAAAKp</dictionariesDialogGeometry>
+ <timeForNewReleaseCheck>2022-06-08T09:34:01</timeForNewReleaseCheck>
+ <skippedRelease></skippedRelease>
+ <showingDictBarNames>0</showingDictBarNames>
+ <usingSmallIconsInToolbars>0</usingSmallIconsInToolbars>
+ <editDictionaryCommandLine></editDictionaryCommandLine>
+ <maxPictureWidth>0</maxPictureWidth>
+ <maxHeadwordSize>256</maxHeadwordSize>
+ <maxHeadwordsToExpand>0</maxHeadwordsToExpand>
+ <headwordsDialog>
+  <searchMode>0</searchMode>
+  <matchCase>0</matchCase>
+  <autoApply>0</autoApply>
+  <headwordsExportPath></headwordsExportPath>
+  <headwordsDialogGeometry></headwordsDialogGeometry>
+ </headwordsDialog>
+</config>

--- a/install.sh
+++ b/install.sh
@@ -4,16 +4,24 @@ SDC=https://archive.org/download/stardict_collections/archives-english/en-head
 
 install() {
   echo "Making $SHORT directory"
-  mkdir -p ~/dictionaries/$SHORT
+  mkdir -p ~/.pop-dictionary/dictionaries/"$SHORT"
 
   echo "Downloading $SHORT dictionary..."
-  cd ~/dictionaries/$SHORT && \
-    wget $SDC/$FILE && \
-    tar -xzvf $FILE
-  
+  cd ~/.pop-dictionary/dictionaries/"$SHORT" &&
+    wget $SDC/"$FILE" &&
+    tar -xzvf "$FILE"
+
   echo "Installing icon $ICON"
-  cp icons/$ICON ~/dictionaries/$SHORT/
+  cp icons/"$ICON" ~/.pop-dictionary/dictionaries/"$SHORT"/
 }
+
+# Clone repo
+
+git clone https://github.com/canadaduane/pop-dictionary.git ~/.pop-dictionary
+
+# Install GoldenDict
+
+flatpak install flathub org.goldendict.GoldenDict
 
 # Install the Pop!_OS launcher
 
@@ -26,25 +34,28 @@ chmod +x ~/.local/share/pop-launcher/plugins/define/define
 FILE=American_Heritage_Dictionary_4th_Ed.tar.gz
 SHORT=amerher
 ICON=American_Heritage_Dictionary_4th_Ed.jpg
-install()
+install
 
 # Collins Thesaurus
 
 FILE=Collins_Thesaurus.tar.gz
 SHORT=collins
 ICON=Collins_Thesaurus.png
-install()
+install
 
 # Oxford
 
 FILE=Oxford_Advanced_Learner_s_Dictionary.tar.gz
 SHORT=oxford
 ICON=Oxford_Advanced_Learner_s_Dictionary.png
-install()
+install
 
 # WordNet
 
 FILE=WordNet_3.tar.gz
 SHORT=wordnet
 ICON=WordNet_3.png
-install()
+install
+
+# Create new config for GoldenDict
+cp ~/.pop-dictionary/goldendict-config ~/.var/app/org.goldendict.GoldenDict/.goldendict/config


### PR DESCRIPTION
Great idea by the way. I have another one that might be of interest to you at a later date. But, for now, there's a few things in this PR that might be helpful to this repo.

1) The title mentioned that I fixed the script. That's because on my machine at least, I ran into the following issue:
```
❯ ./install.sh 
./install.sh: line 33: syntax error near unexpected token `FILE=Collins_Thesaurus.tar.gz'
./install.sh: line 33: `FILE=Collins_Thesaurus.tar.gz'
```
Now to my eyes the script seemed fine, but using `shellcheck` I had the following output:
```
❯ shellcheck install.sh 

In install.sh line 29:
install()
^-- SC1073 (error): Couldn't parse this function. Fix to allow more checks.


In install.sh line 33:
FILE=Collins_Thesaurus.tar.gz
^-- SC1064 (error): Expected a { to open the function definition.
^-- SC1072 (error):  Fix any mentioned problems and try again.
```

To fix this, apparently, you can remove the `()` at a function call (I know, I don't like the look of it either). After removing the `()` and `shellcheck`-ing again. `"$EXAMPLE"` was recommended to _prevent word splitting_. The long and short of it is that the script now runs.

---

2) Extending the automation so it's just 1 line in the terminal. You can see in the change to the `README.md` that it just get's the raw file the `install.sh` script and executes it there. Which includes: 
 - Downloading this repo to a hidden folder in the home directory (I like to keep my home directory clean)
 - Installing GoldenDict
 - Changing the download location and extraction of the downloaded dictionaries into this repo (Just felt appropriate)
 - Adding the config changes for GoldenDict to point at the dictionaries


